### PR TITLE
use lodash's merge instead of defaults when no plugins are loaded

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,7 @@ function OniyiHttpClient(params) {
     // call request directly, if there are no plugins loaded in this client
     if (!Array.isArray(plugins) || plugins.length < 1) {
       logger.info('no plugins loaded, uri: %s', initialParams.uri);
-      return new request.Request(_.defaults({}, defaults, initialParams));
+      return new request.Request(_.merge({}, defaults, initialParams));
     }
 
     // merge params with defaults


### PR DESCRIPTION
`_.merge()` is already used when plugins are present, and using `_.merge()` when no plugins are present would provide consistent behavior.
